### PR TITLE
Use custom token in GitHub Actions

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t ghcr.io/tekclinic/doctors-ms:${{ github.sha }} --build-arg GITHUB_ACTOR=${{ github.actor }} \
-            --build-arg GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} .
+          docker build -t ghcr.io/tekclinic/doctors-ms:${{ github.sha }} --build-arg GITHUB_ACTOR=${{ secrets.ACTOR }} \
+            --build-arg GITHUB_TOKEN=${{ secrets.TOKEN }} .
           docker tag ghcr.io/tekclinic/doctors-ms:${{ github.sha }} ghcr.io/tekclinic/doctors-ms:latest
 
       - name: Push Docker image

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: '1.22.1'
           cache: false
-      - run: git config --global url."https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+      - run: git config --global url."https://${{ secrets.ACTOR }}:${{ secrets.TOKEN }}@github.com/".insteadOf "https://github.com/"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
GITHUB_TOKEN has permission to access only its own repository and can't access another private repository of the organization.